### PR TITLE
mission join, leave and conditional rendering

### DIFF
--- a/src/components/MissionEntry.js
+++ b/src/components/MissionEntry.js
@@ -1,15 +1,43 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
-const MissionEntry = ({ mission }) => (
-  <tr>
-    <td>{JSON.parse(mission).mission_name}</td>
-    <td>{JSON.parse(mission).description}</td>
-    <td>probably not a member yet</td>
-    <td>
-      <button type="button">Join mission</button>
-    </td>
-  </tr>
-);
+const MissionEntry = ({ mission }) => {
+  mission = JSON.parse(mission);
+  const dispatch = useDispatch();
+
+  const membershipStatus = (e) => {
+    const statusID = e.target.id;
+    const status = e.target.innerHTML;
+    if (status === 'Join mission') {
+      dispatch(joinMission(statusID));
+      e.target.innerHTML = 'Leave mission';
+    } else {
+      dispatch(leaveMission(statusID));
+      e.target.innerHTML = 'Join mission';
+    }
+  };
+  return (
+    <tr>
+      <td>{mission.mission_name}</td>
+      <td>{mission.description}</td>
+      <td>
+        {
+          mission.reserved ? 'Active Member' : 'NOT A MEMBER'
+        }
+      </td>
+      <td>
+        <button
+          type="button"
+          id={mission.mission_id}
+          onClick={(e) => membershipStatus(e)}
+        >
+          Join mission
+        </button>
+      </td>
+    </tr>
+  );
+};
 
 MissionEntry.propTypes = {
   mission: PropTypes.string.isRequired,

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -11,7 +11,18 @@ export const fetchMissions = createAsyncThunk('missions/fetchMissions', async ()
 export const missionsSlice = createSlice({
   name: 'missions',
   initialState: [],
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const newGuy = state.find((mission) => mission.mission_id === action.payload);
+      newGuy.reserved = true;
+      console.log(`state: ${state} \t action: ${newGuy.reserved}`);
+    },
+    leaveMission: (state, action) => {
+      const newGuy = state.find((mission) => mission.mission_id === action.payload);
+      newGuy.reserved = false;
+      console.log(`state: ${state} \t action: ${newGuy.reserved}`);
+    },
+  },
   extraReducers: {
     [fetchMissions.fulfilled]: (state, action) => {
       let newState = state.missions;
@@ -20,5 +31,7 @@ export const missionsSlice = createSlice({
     },
   },
 });
+
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
- Wrote actions and reducers for joining and leaving missions
  > [ ] When a user clicks the "Join Mission" button the mission's ID is passed to the corresponding action and the mission's state is given a new key/value - reserved: true.

  > [ ] When a user clicks the "leave Mission" button the mission's ID is passed to the corresponding action and the mission's state is given a new key/value - reserved: false.

- Missions that the user has joined already show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
